### PR TITLE
Fix 'File Not Found' error when clicking a route action

### DIFF
--- a/src/Common.ts
+++ b/src/Common.ts
@@ -96,7 +96,7 @@ export default class Common {
       html += '<tr>';
       row.forEach(item => {
         if (item.match(/app\\/i)) {
-          html += `<td><a href="file://${workspace.rootPath}/${item.replace(/@.+$/, '')}.php" class="app-item">` + item + '</a></td>';
+          html += `<td><a href="file://${workspace.rootPath}/${item.replace(/@.+$/, '').replace(/^App/, 'app')}.php" class="app-item">` + item + '</a></td>';
         } else {
           html += '<td>' + item + '</td>';
         }


### PR DESCRIPTION
Systems with case-senstive file paths (linux based) fail to open controller when clicking the action in "Route List".
The reason is "App\Http\Controllers" needs to be replaced by "app\Http\Controllers"