### PR TITLE
Add settings to choose default options for artisan serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,16 @@
           "default": "php",
           "description": "Sets a custom location to the php executable"
         },
+        "artisan.serve.defaultHost": {
+          "type": "string",
+          "default": "localhost",
+          "description": "Sets the default server address for artisan serve"
+        },
+        "artisan.serve.defaultPort": {
+          "type": "string",
+          "default": "8000",
+          "description": "Sets the default port address for artisan serve"
+        },
         "artisan.docker.enabled": {
           "type": "boolean",
           "default": false,

--- a/src/commands/base/Serve.ts
+++ b/src/commands/base/Serve.ts
@@ -1,4 +1,4 @@
-import { window, Terminal } from 'vscode'
+import { workspace, window, Terminal } from 'vscode'
 import Common from '../../Common'
 
 export default class Server extends Common {
@@ -9,12 +9,16 @@ export default class Server extends Common {
   private static port: string
 
   public static async run(useDefaults = false) {
+    
+    let config = workspace.getConfiguration("artisan")
+    let defaultHost = config.get<string>("serve.defaultHost")
+    let defaultPort = config.get<string>("serve.defaultPort")
 
-    let host = useDefaults ? '' : await this.getInput('Should I use a specific host (Default: localhost)?')
-    let port = useDefaults ? '' : await this.getInput('Should I use a specific port (Default: 8000)?')
+    let host = useDefaults ? '' : await this.getInput(`Should I use a specific host (Default: ${defaultHost})?`)
+    let port = useDefaults ? '' : await this.getInput(`Should I use a specific port (Default: ${defaultPort})?`)
 
-    this.host = host.length > 0 ? host : 'localhost'
-    this.port = port.length > 0 ? port : '8000'
+    this.host = host.length > 0 ? host : defaultHost
+    this.port = port.length > 0 ? port : defaultPort
 
     // let command = `serve ${'--host=' + this.host} ${'--port=' + this.port}`
 

--- a/src/commands/base/Serve.ts
+++ b/src/commands/base/Serve.ts
@@ -11,8 +11,8 @@ export default class Server extends Common {
   public static async run(useDefaults = false) {
     
     let config = workspace.getConfiguration("artisan")
-    let defaultHost = config.get<string>("serve.defaultHost")
-    let defaultPort = config.get<string>("serve.defaultPort")
+    let defaultHost = config.get<string>("serve.defaultHost", 'localhost')
+    let defaultPort = config.get<string>("serve.defaultPort", '8000')
 
     let host = useDefaults ? '' : await this.getInput(`Should I use a specific host (Default: ${defaultHost})?`)
     let port = useDefaults ? '' : await this.getInput(`Should I use a specific port (Default: ${defaultPort})?`)


### PR DESCRIPTION
Two new settings options added:

- **artisan.serve.defaultHost** (default: localhost)
- **artisan.serve.defaultPort** (default: 8000)


These settings are used when running the default server command, or when the server host/port input boxes are empty. The configured values are displayed in the input help text so it's always clear what it will default to.

Out of the box this should work identically to the current code, but allows users to configure their preferred default hostname or port if they wish.