### PR TITLE
Quote migration name from make:migration input in case it has spaces

### DIFF
--- a/src/commands/make/Migration.ts
+++ b/src/commands/make/Migration.ts
@@ -24,7 +24,7 @@ export default class MakeMigration extends Common {
       tableName = await this.getInput('What is the name of the table?')
     }
 
-    let command = `make:migration ${migrationName} ${createTable ? '--create=' + tableName : ''} ${modifyTable ? '--table=' + tableName : ''}`
+    let command = `make:migration "${migrationName}" ${createTable ? '--create=' + tableName : ''} ${modifyTable ? '--table=' + tableName : ''}`
 
     // Generate the controller
     this.execCmd(command, async (info) => {


### PR DESCRIPTION
This adds quotes around `${migrationName}` when calling the command. Laravel takes care of snake_casing the file name in the end either way.

A lot of times I would just write `artisan make:migration "Add column xxx to myTable"` and to do this with the extension, I would need to add the quotes in the input that appears in vscode, which feels a bit unnecessary.