### PR TITLE
Fixes unnecessary output panel toggling

### DIFF
--- a/src/Common.ts
+++ b/src/Common.ts
@@ -126,7 +126,6 @@ export default class Common {
     return new Promise<CommandInfo>(resolve => {
       cp.exec(cmd, { cwd: artisanRoot, maxBuffer: maxBuffer }, (err, stdout, stderr) => {
         Output.command(stdout.trim());
-        Output.showConsole();
         if (err) {
           Output.command('-----------------------------------');
           Output.error(err.message.trim());


### PR DESCRIPTION
This PR fixes the forced display of the output panel/channel every time a message is logged.

The log messages will continue to function as expected, but the panel will not be activated for each new output.