### PR TITLE
Adding an option `--parent` to `make:controller`

### DIFF
--- a/src/commands/make/Controller.ts
+++ b/src/commands/make/Controller.ts
@@ -15,18 +15,30 @@ export default class MakeController extends Common {
     let type = (await this.getListInput('What type of controller is this?', ['Basic', 'Resource', 'API'])).toLowerCase() as ControllerType;
 
     let refModel = false;
+    let refParent = false;
     let modelToUse = '';
+    let parentToUse = '';
+    let modelToUseCommands = [];
     if (type != 'basic') {
       // Determine the model reference
       refModel = await this.getYesNo('Should this reference a model?');
       if (refModel) {
         modelToUse = await this.getInput('What is the name of the model?');
+        modelToUseCommands.push(`--model=${modelToUse}`);
+
+        // Determine the parent model reference
+        refParent = await this.getYesNo('Should this reference a parent model?');
+        if (refParent) {
+          parentToUse = await this.getInput('What is the name of the parent model?');
+          modelToUseCommands.push(`--parent=${parentToUse}`);
+        }
+
+        modelToUseCommands.push(`--no-interaction`);
       }
     }
 
-    let modelToUseCommand = refModel ? `--model=${modelToUse} --no-interaction` : '';
     let typeCommand = type === 'resource' ? '--resource' : type === 'api' ? '--api' : '';
-    let command = `make:controller ${ctrlName} ${typeCommand} ${modelToUseCommand}`;
+    let command = `make:controller ${ctrlName} ${typeCommand} ${modelToUseCommands.join(' ')}`;
     // let command = `make:controller ${ctrlName} ${isResource ? '--resource' : ''} ${isAPI ? '--api' : ''}`.trim()
 
     // Generate the controller


### PR DESCRIPTION
This PR updated adding an option `--parent` to `make:controller` command on `Controller.ts` .
Users can reference a parent model on controller.